### PR TITLE
Optimized code for wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ Here is a comparison of WebAssembly binary size (built with TinyGo) when using t
 | atan2        |      167 |    782 |   21% |
 | exp          |      501 |   2722 |   18% |
 | fract        |      206 |    154 |  133% |
-| hypot        |       94 |    203 |   46% |
+| hypot        |       67 |    203 |   33% |
 | ln           |      196 |   4892 |    4% |
 | powf         |      739 |   9167 |    8% |
 | round        |      129 |    171 |   75% |
 | sin          |      125 |   1237 |   10% |
-| sqrt         |       82 |     57 |  143% |
+| sqrt         |       57 |     57 |  100% |
 | tan          |      138 |   1137 |   12% |
 | trunc        |       57 |     57 |  100% |
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Here is a comparison of WebAssembly binary size (built with TinyGo) when using t
 
 | function     | tinymath | stdlib | ratio |
 | ------------ | --------:| ------:| -----:|
+| atan         |      106 |    367 |   28% |
 | atan2        |      167 |    782 |   21% |
 | exp          |      501 |   2722 |   18% |
 | fract        |      206 |    154 |  133% |
@@ -36,6 +37,8 @@ Here is a comparison of WebAssembly binary size (built with TinyGo) when using t
 | powf         |      739 |   9167 |    8% |
 | round        |      129 |    171 |   75% |
 | sin          |      125 |   1237 |   10% |
+| sqrt         |       82 |     57 |  143% |
+| tan          |      138 |   1137 |   12% |
 | trunc        |       57 |     57 |  100% |
 
 To reproduce: `python3 size_bench.py`

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Here is a comparison of WebAssembly binary size (built with TinyGo) when using t
 | ------------ | --------:| ------:| -----:|
 | atan         |      106 |    367 |   28% |
 | atan2        |      167 |    782 |   21% |
-| exp          |      501 |   2722 |   18% |
-| fract        |      206 |    154 |  133% |
+| exp          |      463 |   2722 |   17% |
+| fract        |      166 |    154 |  107% |
 | hypot        |       67 |    203 |   33% |
 | ln           |      196 |   4892 |    4% |
-| powf         |      739 |   9167 |    8% |
+| powf         |      701 |   9167 |    7% |
 | round        |      129 |    171 |   75% |
 | sin          |      125 |   1237 |   10% |
 | sqrt         |       57 |     57 |  100% |

--- a/README.md
+++ b/README.md
@@ -29,15 +29,13 @@ Here is a comparison of WebAssembly binary size (built with TinyGo) when using t
 | function     | tinymath | stdlib | ratio |
 | ------------ | --------:| ------:| -----:|
 | atan2        |      167 |    782 |   21% |
-| exp          |      535 |   2722 |   19% |
+| exp          |      501 |   2722 |   18% |
 | fract        |      206 |    154 |  133% |
 | hypot        |       94 |    203 |   46% |
 | ln           |      196 |   4892 |    4% |
-| powf         |      859 |   9167 |    9% |
+| powf         |      739 |   9167 |    8% |
 | round        |      129 |    171 |   75% |
-| sin          |      198 |   1237 |   16% |
-| trunc        |      136 |     57 |  238% |
+| sin          |      125 |   1237 |   10% |
+| trunc        |       57 |     57 |  100% |
 
 To reproduce: `python3 size_bench.py`
-
-The two functions that are bigger in tinymath (but still small!) are the ones that have an optimized wasm-specific assembly in the standard library implementation. We're working on adding such assembly code on our side as well.

--- a/arch_nowasm.go
+++ b/arch_nowasm.go
@@ -18,6 +18,17 @@ func Floor(self float32) float32 {
 	return float32(res)
 }
 
+// Approximates the square root of a number with an average deviation of ~5%.
+//
+// Returns [`NAN`] if `self` is a negative number.
+func Sqrt(self float32) float32 {
+	if self >= 0.0 {
+		return FromBits((ToBits(self) + 0x3f80_0000) >> 1)
+	} else {
+		return NaN
+	}
+}
+
 // Returns the integer part of a number.
 func Trunc(self float32) float32 {
 	const MANTISSA_MASK = 0b0000_0000_0111_1111_1111_1111_1111_1111

--- a/arch_nowasm.go
+++ b/arch_nowasm.go
@@ -1,3 +1,5 @@
+//go:build !tinygo.wasm
+
 package tinymath
 
 // Functions that can be optimized for wasm

--- a/arch_tinygo.go
+++ b/arch_tinygo.go
@@ -17,6 +17,10 @@ func Floor(self float32) float32 {
 	return float32(math.Floor(float64(self)))
 }
 
+func Sqrt(self float32) float32 {
+	return float32(math.Sqrt(float64(self)))
+}
+
 func Trunc(self float32) float32 {
 	return float32(math.Trunc(float64(self)))
 }

--- a/arch_tinygo.go
+++ b/arch_tinygo.go
@@ -7,7 +7,10 @@ package tinymath
 //
 // https://github.com/tinygo-org/tinygo/blob/6384ecace093df2d0b93915886954abfc4ecfe01/compiler/intrinsics.go#L114C5-L114C22
 
-import "math"
+import (
+	"math"
+	"math/bits"
+)
 
 func Ceil(self float32) float32 {
 	return float32(math.Ceil(float64(self)))
@@ -26,10 +29,5 @@ func Trunc(self float32) float32 {
 }
 
 func leadingZeros(x uint32) uint32 {
-	var n uint32 = 32
-	for x != 0 {
-		x >>= 1
-		n -= 1
-	}
-	return n
+	return uint32(bits.LeadingZeros32(x))
 }

--- a/arch_tinygo.go
+++ b/arch_tinygo.go
@@ -1,0 +1,31 @@
+//go:build tinygo.wasm
+
+package tinymath
+
+// Functions in this file are inlined and optimized by TinyGo compiler.
+// The result is a single wasm instruction.
+//
+// https://github.com/tinygo-org/tinygo/blob/6384ecace093df2d0b93915886954abfc4ecfe01/compiler/intrinsics.go#L114C5-L114C22
+
+import "math"
+
+func Ceil(self float32) float32 {
+	return float32(math.Ceil(float64(self)))
+}
+
+func Floor(self float32) float32 {
+	return float32(math.Floor(float64(self)))
+}
+
+func Trunc(self float32) float32 {
+	return float32(math.Trunc(float64(self)))
+}
+
+func leadingZeros(x uint32) uint32 {
+	var n uint32 = 32
+	for x != 0 {
+		x >>= 1
+		n -= 1
+	}
+	return n
+}

--- a/size_bench/std/atan.go
+++ b/size_bench/std/atan.go
@@ -1,0 +1,10 @@
+//go:build !none || atan
+
+package main
+
+import "math"
+
+//go:export f
+func Atan(a float64) float64 {
+	return math.Atan(a)
+}

--- a/size_bench/std/sqrt.go
+++ b/size_bench/std/sqrt.go
@@ -1,0 +1,10 @@
+//go:build !none || sqrt
+
+package main
+
+import "math"
+
+//go:export f
+func Sqrt(x float64) float64 {
+	return math.Sqrt(x)
+}

--- a/size_bench/std/tan.go
+++ b/size_bench/std/tan.go
@@ -1,0 +1,10 @@
+//go:build !none || tan
+
+package main
+
+import "math"
+
+//go:export f
+func Tan(x float64) float64 {
+	return math.Tan(x)
+}

--- a/size_bench/tiny/atan.go
+++ b/size_bench/tiny/atan.go
@@ -1,0 +1,10 @@
+//go:build !none || atan
+
+package main
+
+import "github.com/orsinium-labs/tinymath"
+
+//go:export f
+func Atan(a float32) float32 {
+	return tinymath.Atan(a)
+}

--- a/size_bench/tiny/sqrt.go
+++ b/size_bench/tiny/sqrt.go
@@ -1,0 +1,10 @@
+//go:build !none || sqrt
+
+package main
+
+import "github.com/orsinium-labs/tinymath"
+
+//go:export f
+func Sqrt(x float32) float32 {
+	return tinymath.Sqrt(x)
+}

--- a/size_bench/tiny/tan.go
+++ b/size_bench/tiny/tan.go
@@ -1,0 +1,10 @@
+//go:build !none || tan
+
+package main
+
+import "github.com/orsinium-labs/tinymath"
+
+//go:export f
+func Tan(x float32) float32 {
+	return tinymath.Tan(x)
+}

--- a/tinymath.go
+++ b/tinymath.go
@@ -349,17 +349,6 @@ func Sign(self float32) float32 {
 	}
 }
 
-// Approximates the square root of a number with an average deviation of ~5%.
-//
-// Returns [`NAN`] if `self` is a negative number.
-func Sqrt(self float32) float32 {
-	if self >= 0.0 {
-		return FromBits((ToBits(self) + 0x3f80_0000) >> 1)
-	} else {
-		return NaN
-	}
-}
-
 func extractExponentBits(self float32) uint32 {
 	return (ToBits(self) & expMask) >> mantissaBits
 }


### PR DESCRIPTION
Some functions from the module are available as a single wasm instruction. TinyGo emits such instruction for a hardcoded list of stdlib math functions.

The PR makes tinymath to use such instructions whenever possible when compiling to wasm.

Special thanks to @aykevl for explaining how TinyGo does the optimizations.